### PR TITLE
Rename utils to flashpack to remain consistent with A/M

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TOP_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 CODK_FLASHPACK_URL := https://github.com/01org/CODK-Z-Flashpack.git
-CODK_FLASHPACK_DIR := $(TOP_DIR)/utils
+CODK_FLASHPACK_DIR := $(TOP_DIR)/flashpack
 CODK_FLASHPACK_TAG := master
 OUT_DIR := $(TOP_DIR)/out
 ZEPHYR_DIR := $(TOP_DIR)/../zephyr


### PR DESCRIPTION
Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>