### PR TITLE
Ignore missing package when purging modemmanager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ check-root:
 install-dep: check-root
 	apt-get update
 	apt-get install -y git make gcc gcc-multilib g++ libc6-dev-i386 g++-multilib python3-ply
-	apt-get purge -y modemmanager
+	dpkg --purge modemmanager
 	cp -f $(CODK_FLASHPACK_DIR)/drivers/rules.d/*.rules /etc/udev/rules.d/
 	service udev restart
 	usermod -a -G dialout $(SUDO_USER)


### PR DESCRIPTION
Signed-off-by: Brian Baltz <brian.a.baltz@intel.com>