### PR TITLE
Remove BOARD definition from example Makefiles

### DIFF
--- a/arc/examples/blank/Makefile
+++ b/arc/examples/blank/Makefile
@@ -1,4 +1,3 @@
-BOARD ?= arduino_101_sss
 CONF_FILE = prj.conf
 
 include ${ZEPHYR_BASE}/Makefile.inc

--- a/arc/examples/hello/Makefile
+++ b/arc/examples/hello/Makefile
@@ -1,4 +1,3 @@
-BOARD ?= arduino_101_sss
 CONF_FILE = prj.conf
 
 include ${ZEPHYR_BASE}/Makefile.inc

--- a/x86/examples/blank/Makefile
+++ b/x86/examples/blank/Makefile
@@ -1,4 +1,3 @@
-BOARD ?= arduino_101
 CONF_FILE = prj.conf
 
 include ${ZEPHYR_BASE}/Makefile.inc

--- a/x86/examples/hello/Makefile
+++ b/x86/examples/hello/Makefile
@@ -1,4 +1,3 @@
-BOARD ?= arduino_101
 CONF_FILE = prj.conf
 
 include ${ZEPHYR_BASE}/Makefile.inc


### PR DESCRIPTION
These are already defined when building x86 and arc, in the
"compile-arc" and "compile-x86" targets in the main Makefile